### PR TITLE
Better password handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Output file name now defaults to the log date
-- `dpdocs` will ask for the CAPWATCH password if it will be refreshing the cache instead of throwing an error
 
 ### Deprecated
 
 ### Removed
-- `--password` flag removed from command-line interface
 
 ### Fixed
 
 ### Security
-- Instead of typing the eServices password on the command line in the clear, a no-echo scan approach is now used
 
-## [v1.0.0]
+## [1.0.0]
 
 ### Changed
 - Output file name now defaults to the log date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+- Output file name now defaults to the log date
+- `dpdocs` will ask for the CAPWATCH password if it will be refreshing the cache instead of throwing an error
+
+### Deprecated
+
+### Removed
+- `--password` flag removed from command-line interface
+
+### Fixed
+
+### Security
+- Instead of typing the eServices password on the command line in the clear, a no-echo scan approach is now used
+
+## [0.1.0]
+
+### Added
+- Fetching membership data from CAPWATCH
+- Parsing squadron Table of Organization data from a YAML config file
+- Creating Barcode Attendance Logs from CAPWATCH data and YAML config
+
+[unreleased]: https://github.com/ut080/bcs-portal/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ut080/bcs-portal/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Instead of typing the eServices password on the command line in the clear, a no-echo scan approach is now used
 
+## [v1.0.0]
+
+### Changed
+- Output file name now defaults to the log date
+- `dpdocs` will ask for the CAPWATCH password if it will be refreshing the cache instead of throwing an error
+
+### Removed
+- `--password` flag removed from command-line interface
+
+### Security
+- Instead of typing the eServices password on the command line in the clear, a no-echo scan approach is now used
+
 ## [0.1.0]
 
 ### Added
@@ -31,4 +43,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Creating Barcode Attendance Logs from CAPWATCH data and YAML config
 
 [unreleased]: https://github.com/ut080/bcs-portal/compare/v0.1.0...HEAD
+[1.0.0]: https://github.com/ut080/bcs-portal/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/ut080/bcs-portal/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ LDFLAGS = -ldflags "-s -X main.BuildTime=${BUILD_TIME} -X main.GitRevision=${GIT
 bin/dpdocs: $(foreach f, $(SRC), $(f))
 	go build ${LDFLAGS} -o bin/dpdocs cmd/dpdocs/main.go
 
+.PHONY: install
+install: bin/dpdocs
+	go run build/dpdocs/install.go $(CURDIR)
+	cp bin/dpdocs ${HOME}/.local/bin/
+
 .PHONY: test
 test:
 	go test -v -count=1 ./...

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,7 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/attendance/barcode_log_test.go
+++ b/pkg/attendance/barcode_log_test.go
@@ -51,7 +51,8 @@ func loadCAPWATCHData() (map[uint]pkg.Member, time.Time, error) {
 	username := viper.GetString("capwatch.username")
 	password := viper.GetString("capwatch.password")
 	refresh := viper.GetInt("capwatch.refresh")
-	client := capwatch.NewClient(orgID, username, password, refresh, logging.Logger{})
+	client := capwatch.NewClient(orgID, username, refresh, logging.Logger{})
+	client.SetCapwatchPassword([]byte(password))
 
 	cacheFile := filepath.Join(testDataDir, "cache", "capwatch.zip")
 

--- a/pkg/attendance/member.go
+++ b/pkg/attendance/member.go
@@ -7,25 +7,6 @@ import (
 	"github.com/ut080/bcs-portal/pkg"
 )
 
-type Member struct {
-	CAPID uint
-	Name  string
-}
-
-func NewMemberFromDomainMember(member pkg.Member) Member {
-	return Member{
-		CAPID: member.CAPID,
-		Name:  member.String(),
-	}
-}
-
-func (m Member) LaTeX() string {
-	s := strings.Replace(memberTemplate, "$(CAPID)", strconv.Itoa(int(m.CAPID)), 1)
-	s = strings.Replace(s, "$(NAME)", m.Name, 1)
-
-	return s
-}
-
 const memberTemplate = `\stepcounter{lineNumber}
     \barcode{$(CAPID)}                                &
     $(NAME)                                           &
@@ -35,3 +16,22 @@ const memberTemplate = `\stepcounter{lineNumber}
     \FormCheckBox{uniform\arabic{lineNumber}}{}       \\
     \hline
 `
+
+type Member struct {
+	CAPID uint
+	Name  string
+}
+
+func NewMemberFromDomainMember(domainMember pkg.Member) (member Member) {
+	member.CAPID = domainMember.CAPID
+	member.Name = domainMember.String()
+
+	return member
+}
+
+func (m Member) LaTeX() (latex string) {
+	latex = strings.Replace(memberTemplate, "$(CAPID)", strconv.Itoa(int(m.CAPID)), 1)
+	latex = strings.Replace(latex, "$(NAME)", m.Name, 1)
+
+	return latex
+}

--- a/pkg/capwatch/client_test.go
+++ b/pkg/capwatch/client_test.go
@@ -22,12 +22,13 @@ func (suite *ClientTestSuite) SetupTest() {
 }
 
 func (suite *ClientTestSuite) TestFetch() {
-	suite.T().Skip("This test hits CAPWATCH, comment out the Skip() method if you want it to run.")
+	//suite.T().Skip("This test hits CAPWATCH, comment out the Skip() method if you want it to run.")
 	orgID := viper.GetString("capwatch.orgid")
 	username := viper.GetString("capwatch.username")
 	password := viper.GetString("capwatch.password")
 	refresh := viper.GetInt("capwatch.refresh")
-	client := NewClient(orgID, username, password, refresh, logging.Logger{})
+	client := NewClient(orgID, username, refresh, logging.Logger{})
+	client.SetCapwatchPassword([]byte(password))
 
 	cacheFile := filepath.Join(testDataDir, "cache", "capwatch.zip")
 

--- a/pkg/capwatch/dump.go
+++ b/pkg/capwatch/dump.go
@@ -19,14 +19,17 @@ type Dump struct {
 	lastSync time.Time
 }
 
-func NewDump(dump []byte, lastSync time.Time) *Dump {
-	return &Dump{
+func NewDump(dump []byte, lastSync time.Time) (d *Dump) {
+	nd := Dump{
 		raw:      dump,
 		lastSync: lastSync,
 	}
+
+	d = &nd
+	return d
 }
 
-func (d *Dump) openCSV(filename string) (*csv.Reader, error) {
+func (d *Dump) openCSV(filename string) (reader *csv.Reader, err error) {
 	rawArchive := bytes.NewReader(d.raw)
 	archive, err := zip.NewReader(rawArchive, int64(len(d.raw)))
 	if err != nil {
@@ -38,7 +41,8 @@ func (d *Dump) openCSV(filename string) (*csv.Reader, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	return csv.NewReader(f), nil
+	reader = csv.NewReader(f)
+	return reader, nil
 }
 
 func (d *Dump) FetchMembers() (members map[uint]pkg.Member, err error) {

--- a/pkg/capwatch/dump_test.go
+++ b/pkg/capwatch/dump_test.go
@@ -26,7 +26,8 @@ func (suite *DumpTestSuite) TestFetchMembers() {
 	username := viper.GetString("capwatch.username")
 	password := viper.GetString("capwatch.password")
 	refresh := viper.GetInt("capwatch.refresh")
-	client := NewClient(orgID, username, password, refresh, logging.Logger{})
+	client := NewClient(orgID, username, refresh, logging.Logger{})
+	client.SetCapwatchPassword([]byte(password))
 
 	cacheFile := filepath.Join(testDataDir, "cache", "capwatch.zip")
 

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -8,29 +8,32 @@ import (
 )
 
 // Copy is a basic file copy utility function, because this doesn't exist in the std library for... reasons.
-func Copy(srcPath, destPath string) error {
+func Copy(srcPath, destPath string) (err error) {
 	src, err := os.Open(srcPath)
 	if err != nil {
-		return errors.WithStack(err)
+		err = errors.WithStack(err)
+		return err
 	}
 	defer src.Close()
 
 	dest, err := os.Create(destPath)
 	if err != nil {
-		return errors.WithStack(err)
+		err = errors.WithStack(err)
+		return err
 	}
 	defer dest.Close()
 
 	_, err = io.Copy(dest, src)
 	if err != nil {
-		return errors.WithStack(err)
+		err = errors.WithStack(err)
+		return err
 	}
 
 	return nil
 }
 
-func Move(srcPath, destPath string) error {
-	err := Copy(srcPath, destPath)
+func Move(srcPath, destPath string) (err error) {
+	err = Copy(srcPath, destPath)
 	if err != nil {
 		return err
 	}
@@ -43,21 +46,24 @@ func Move(srcPath, destPath string) error {
 	return nil
 }
 
-func Write(destPath, content string) error {
+func Write(destPath, content string) (err error) {
 	dest, err := os.Create(destPath)
 	if err != nil {
-		return errors.WithStack(err)
+		err = errors.WithStack(err)
+		return err
 	}
 	defer dest.Close()
 
 	_, err = io.WriteString(dest, content)
 	if err != nil {
-		return errors.WithStack(err)
+		err = errors.WithStack(err)
+		return err
 	}
 
 	err = dest.Sync()
 	if err != nil {
-		return errors.WithStack(err)
+		err = errors.WithStack(err)
+		return err
 	}
 
 	return nil

--- a/pkg/flight.go
+++ b/pkg/flight.go
@@ -12,12 +12,13 @@ type Flight struct {
 	Elements        []Element
 }
 
-func (f *Flight) PopulateMemberData(members map[uint]Member, accounted *mapset.Set[uint]) error {
+func (f *Flight) PopulateMemberData(members map[uint]Member, accounted *mapset.Set[uint]) (err error) {
 	if f.FlightCommander.Assignee != nil {
 		cc, ok := members[f.FlightCommander.Assignee.CAPID]
 		if !ok {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.Errorf("no member found with CAPID %d", f.FlightCommander.Assignee.CAPID)
+			err = errors.Errorf("no member found with CAPID %d", f.FlightCommander.Assignee.CAPID)
+			return err
 		}
 		f.FlightCommander.Assignee = &cc
 		(*accounted).Add(cc.CAPID)
@@ -27,7 +28,8 @@ func (f *Flight) PopulateMemberData(members map[uint]Member, accounted *mapset.S
 		ccf, ok := members[f.FlightSergeant.Assignee.CAPID]
 		if !ok {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.Errorf("no member found with CAPID %d", f.FlightSergeant.Assignee.CAPID)
+			err = errors.Errorf("no member found with CAPID %d", f.FlightSergeant.Assignee.CAPID)
+			return err
 		}
 		f.FlightSergeant.Assignee = &ccf
 		(*accounted).Add(ccf.CAPID)
@@ -38,7 +40,8 @@ func (f *Flight) PopulateMemberData(members map[uint]Member, accounted *mapset.S
 		err := element.PopulateMemberData(members, accounted)
 		if err != nil {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.WithStack(err)
+			err = errors.WithStack(err)
+			return err
 		}
 
 		elements = append(elements, element)
@@ -55,12 +58,13 @@ type Element struct {
 	Members           []Member
 }
 
-func (e *Element) PopulateMemberData(members map[uint]Member, accounted *mapset.Set[uint]) error {
+func (e *Element) PopulateMemberData(members map[uint]Member, accounted *mapset.Set[uint]) (err error) {
 	if e.ElementLeader.Assignee != nil {
 		el, ok := members[e.ElementLeader.Assignee.CAPID]
 		if !ok {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.Errorf("no member found with CAPID %d", e.ElementLeader.Assignee.CAPID)
+			err = errors.Errorf("no member found with CAPID %d", e.ElementLeader.Assignee.CAPID)
+			return err
 		}
 		e.ElementLeader.Assignee = &el
 		(*accounted).Add(el.CAPID)
@@ -70,7 +74,8 @@ func (e *Element) PopulateMemberData(members map[uint]Member, accounted *mapset.
 		ael, ok := members[e.AsstElementLeader.Assignee.CAPID]
 		if !ok {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.Errorf("no member found with CAPID %d", e.AsstElementLeader.Assignee.CAPID)
+			err = errors.Errorf("no member found with CAPID %d", e.AsstElementLeader.Assignee.CAPID)
+			return err
 		}
 		e.AsstElementLeader.Assignee = &ael
 		(*accounted).Add(ael.CAPID)
@@ -81,7 +86,8 @@ func (e *Element) PopulateMemberData(members map[uint]Member, accounted *mapset.
 		// TODO: Instead of halting on error, continue to populate and return a slice of errors
 		mbr, ok := members[member.CAPID]
 		if !ok {
-			return errors.Errorf("no member found with CAPID %d", member.CAPID)
+			err = errors.Errorf("no member found with CAPID %d", member.CAPID)
+			return err
 		}
 		elementMembers = append(elementMembers, mbr)
 		(*accounted).Add(mbr.CAPID)

--- a/pkg/grade.go
+++ b/pkg/grade.go
@@ -41,74 +41,77 @@ const (
 	CdtAB       Grade = "C/AB"
 )
 
-func ParseGrade(grade string) (Grade, error) {
-	switch grade {
+func ParseGrade(gradeStr string) (grade Grade, err error) {
+	switch gradeStr {
 	case "Maj Gen":
-		return MajGen, nil
+		grade = MajGen
 	case "Brig Gen":
-		return BrigGen, nil
+		grade = BrigGen
 	case "Col":
-		return Col, nil
+		grade = Col
 	case "Lt Col":
-		return LtCol, nil
+		grade = LtCol
 	case "Maj":
-		return Maj, nil
+		grade = Maj
 	case "Capt":
-		return Capt, nil
+		grade = Capt
 	case "1st Lt":
-		return FirstLt, nil
+		grade = FirstLt
 	case "2d Lt":
-		return SecondLt, nil
+		grade = SecondLt
 	case "SFO":
-		return SFO, nil
+		grade = SFO
 	case "TFO":
-		return TFO, nil
+		grade = TFO
 	case "FO":
-		return FO, nil
+		grade = FO
 	case "CMSgt":
-		return CMSgt, nil
+		grade = CMSgt
 	case "SMSgt":
-		return SMSgt, nil
+		grade = SMSgt
 	case "MSgt":
-		return MSgt, nil
+		grade = MSgt
 	case "TSgt":
-		return TSgt, nil
+		grade = TSgt
 	case "SSgt":
-		return SSgt, nil
+		grade = SSgt
 	case "SM":
-		return SM, nil
+		grade = SM
 	case "C/Col":
-		return CdtCol, nil
+		grade = CdtCol
 	case "C/Lt Col":
-		return CdtLtCol, nil
+		grade = CdtLtCol
 	case "C/Maj":
-		return CdtMaj, nil
+		grade = CdtMaj
 	case "C/Capt":
-		return CdtCapt, nil
+		grade = CdtCapt
 	case "C/1st Lt":
-		return CdtFirstLt, nil
+		grade = CdtFirstLt
 	case "C/2d Lt":
-		return CdtSecondLt, nil
+		grade = CdtSecondLt
 	case "C/CMSgt":
-		return CdtCMSgt, nil
+		grade = CdtCMSgt
 	case "C/SMSgt":
-		return CdtSMSgt, nil
+		grade = CdtSMSgt
 	case "C/MSgt":
-		return CdtMSgt, nil
+		grade = CdtMSgt
 	case "C/TSgt":
-		return CdtTSgt, nil
+		grade = CdtTSgt
 	case "C/SSgt":
-		return CdtSSgt, nil
+		grade = CdtSSgt
 	case "C/SrA":
-		return CdtSrA, nil
+		grade = CdtSrA
 	case "C/A1C":
-		return CdtA1C, nil
+		grade = CdtA1C
 	case "C/Amn":
-		return CdtAmn, nil
+		grade = CdtAmn
 	case "C/AB":
 	case "CADET":
-		return CdtAB, nil
+		grade = CdtAB
+	default:
+		err = errors.Errorf("invalid gradeStr: %s", gradeStr)
+		return "", err
 	}
 
-	return "", errors.Errorf("invalid grade: %s", grade)
+	return grade, nil
 }

--- a/pkg/member.go
+++ b/pkg/member.go
@@ -28,8 +28,8 @@ type MemberGroup struct {
 	Cadets  []Member
 }
 
-func capidSet(members map[uint]Member) mapset.Set[uint] {
-	s := mapset.NewSet[uint]()
+func capidSet(members map[uint]Member) (s mapset.Set[uint]) {
+	s = mapset.NewSet[uint]()
 
 	for u, _ := range members {
 		s.Add(u)
@@ -38,8 +38,8 @@ func capidSet(members map[uint]Member) mapset.Set[uint] {
 	return s
 }
 
-func NewUnassignedMemberGroup(members map[uint]Member, assigned mapset.Set[uint], inactive mapset.Set[uint]) MemberGroup {
-	mg := MemberGroup{Name: "Unassigned"}
+func NewUnassignedMemberGroup(members map[uint]Member, assigned mapset.Set[uint], inactive mapset.Set[uint]) (mg MemberGroup) {
+	mg.Name = "Unassigned"
 
 	diff := capidSet(members).Difference(inactive).Difference(assigned)
 

--- a/pkg/member_type.go
+++ b/pkg/member_type.go
@@ -13,13 +13,16 @@ const (
 	CadetMember  MemberType = "CADET"
 )
 
-func ParseMemberType(memberType string) (MemberType, error) {
-	switch strings.ToUpper(memberType) {
+func ParseMemberType(memberTypeStr string) (mt MemberType, err error) {
+	switch strings.ToUpper(memberTypeStr) {
 	case "SENIOR":
-		return SeniorMember, nil
+		mt = SeniorMember
 	case "CADET":
-		return CadetMember, nil
+		mt = CadetMember
+	default:
+		err = errors.Errorf("invalid member type: %s", memberTypeStr)
+		return "", err
 	}
 
-	return "", errors.Errorf("invalid member type: %s", memberType)
+	return mt, nil
 }

--- a/pkg/staff_group.go
+++ b/pkg/staff_group.go
@@ -10,13 +10,14 @@ type StaffGroup struct {
 	SubGroups []StaffSubGroup
 }
 
-func (sg *StaffGroup) PopulateMemberData(members map[uint]Member, assigned *mapset.Set[uint]) error {
+func (sg *StaffGroup) PopulateMemberData(members map[uint]Member, assigned *mapset.Set[uint]) (err error) {
 	var subgroups []StaffSubGroup
 	for _, group := range sg.SubGroups {
-		err := group.PopulateMemberData(members, assigned)
+		err = group.PopulateMemberData(members, assigned)
 		if err != nil {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.WithStack(err)
+			err = errors.WithStack(err)
+			return err
 		}
 		subgroups = append(subgroups, group)
 	}
@@ -32,12 +33,13 @@ type StaffSubGroup struct {
 	DirectReports []DutyAssignment
 }
 
-func (ssg *StaffSubGroup) PopulateMemberData(members map[uint]Member, assigned *mapset.Set[uint]) error {
+func (ssg *StaffSubGroup) PopulateMemberData(members map[uint]Member, assigned *mapset.Set[uint]) (err error) {
 	if ssg.Leader.Assignee != nil {
 		leader, ok := members[ssg.Leader.Assignee.CAPID]
 		if !ok {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.Errorf("no member found with CAPID %d", ssg.Leader.Assignee.CAPID)
+			err = errors.Errorf("no member found with CAPID %d", ssg.Leader.Assignee.CAPID)
+			return err
 		}
 		ssg.Leader.Assignee = &leader
 		(*assigned).Add(leader.CAPID)

--- a/pkg/table_of_organization.go
+++ b/pkg/table_of_organization.go
@@ -13,15 +13,16 @@ type TableOfOrganization struct {
 	InactiveCAPIDs mapset.Set[uint]
 }
 
-func (to *TableOfOrganization) PopulateMemberData(members map[uint]Member) error {
+func (to *TableOfOrganization) PopulateMemberData(members map[uint]Member) (err error) {
 	assigned := mapset.NewSet[uint]()
 
 	var staffGroups []StaffGroup
 	for _, group := range to.StaffGroups {
-		err := group.PopulateMemberData(members, &assigned)
+		err = group.PopulateMemberData(members, &assigned)
 		if err != nil {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.WithStack(err)
+			err = errors.WithStack(err)
+			return err
 		}
 
 		staffGroups = append(staffGroups, group)
@@ -31,10 +32,11 @@ func (to *TableOfOrganization) PopulateMemberData(members map[uint]Member) error
 
 	var flights []Flight
 	for _, flight := range to.Flights {
-		err := flight.PopulateMemberData(members, &assigned)
+		err = flight.PopulateMemberData(members, &assigned)
 		if err != nil {
 			// TODO: Instead of halting on error, continue to populate and return a slice of errors
-			return errors.WithStack(err)
+			err = errors.WithStack(err)
+			return err
 		}
 		flights = append(flights, flight)
 	}

--- a/pkg/yaml/loader.go
+++ b/pkg/yaml/loader.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ut080/bcs-portal/app/logging"
 )
 
-func LoadYamlDocFromFile(filename string, out interface{}, logger logging.Logger) error {
+func LoadYamlDocFromFile(filename string, out interface{}, logger logging.Logger) (err error) {
 	raw, err := os.ReadFile(filename)
 	if err != nil {
 		logger.Error().Err(err).Str("filename", filename).Msg("failed to read yaml file")


### PR DESCRIPTION
### Changed
- Output file name now defaults to the log date
- `dpdocs` will ask for the CAPWATCH password if it will be refreshing the cache instead of throwing an error

### Removed
- `--password` flag removed from command-line interface

### Security
- Instead of typing the eServices password on the command line in the clear, a no-echo scan approach is now used
